### PR TITLE
Audio feature, learn-to-play page styling, bot + 6 added back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,41 @@
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![website](https://img.shields.io/website-up-down-green-red/http/kidsgoserver.com/.svg?label=online-go)](https://kidsgoserver.com/)
+*******************
+**Initial Setup**
+*******************
 
-# KidsGoServer.com source code
+Getting setup locally takes less than 5 minutes!
 
-This repository contains the source code for web client used by [KidsGoServer.com](https://kidsgoserver.com).
+Requirements:
+- Node.js version 20+ (check with: node -v)
+- Yarn package manager (install with: npm install -g yarn)
 
-# Contributing
+*******************
 
-Feel like making some changes? Excellent! See the [Contributing guide](./CONTRIBUTING.md).
+1. Git clone the project
+
+```
+git clone https://github.com/ScriabinOp8No12/audio-feature-PR.git
+```
+
+2. In a terminal, navigate to the root of the project
+
+```
+cd audio-feature-PR
+```
+
+3. Open the project in your IDE, then return to your original terminal for step 4:
+
+```
+code .
+```
+
+4. Install packages and start the frontend server:
+
+```
+yarn install && npm run dev
+```
+
+5. View the website in your browser:
+
+```
+http://localhost:18888/
+```

--- a/src/views/LearnToPlay/LearnToPlay.styl
+++ b/src/views/LearnToPlay/LearnToPlay.styl
@@ -85,57 +85,8 @@
         background-repeat: no-repeat;
     }
 
-    .chapter-container {
-        position: absolute;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        z-index: 1;
-        width: 7rem;
-    }
-
-    .chapter-1-container {
-        left: "calc(50% - 3.5rem)" % "";
-        top: 12%;
-    }
-
-    .chapter-2-container {
-        right: 20%;
-        top: 24%;
-    }
-
-    .chapter-3-container {
-        top: "calc(50% - 1.5rem)" % "";
-        right: 11%;
-    }
-
-    .chapter-4-container {
-        right: 20%;
-        bottom: 20%;
-    }
-
-    .chapter-5-container {
-        left: "calc(50% - 3.5rem)" % "";
-        bottom: 12%;
-    }
-
-    .chapter-6-container {
-        left: 20%;
-        bottom: 20%;
-    }
-
-    .chapter-7-container {
-        top: "calc(50% - 1.5rem)" % "";
-        left: 12%;
-    }
-
-    .chapter-8-container {
-        left: 20%;
-        top: 24%;
-    }
-
     .ChapterButton {
-        position: relative;
+        position: absolute;
         display: inline-flex;
         width: 3rem;
         height: 3rem;
@@ -156,36 +107,167 @@
             background-image: svg-load("../assets/pages/lessons/active.svg");
             cursor: not-allowed;
         }
+
+        // top bottom
+        &.chapter-1 {
+            left: "calc(50% - 1.5rem)" % "";
+            top: 12%;
+        }
+        &.chapter-5 {
+            left: "calc(50% - 1.5rem)" % "";
+            bottom: 12%;
+        }
+
+        // left right
+        &.chapter-7 {
+            top: "calc(50% - 1.5rem)" % "";
+            left: 12%;
+        }
+        &.chapter-3 {
+            top: "calc(50% - 1.5rem)" % "";
+            right: 11%;
+        }
+
+        // ne se
+        &.chapter-2 {
+            right: 22%
+            top: 22%;
+        }
+        &.chapter-4 {
+            right: 22%
+            bottom: 22%;
+        }
+
+        // nw sw
+        &.chapter-6 {
+            left: 22%
+            bottom: 22%;
+        }
+        &.chapter-8 {
+            left: 22%
+            top: 22%;
+        }
     }
 
     .chapter-text {
-        position: relative;
-        color: #001533;
-        text-align: center;
-        margin-top: 0.5rem;
-        font-size: 1.25rem;
-        background-color:rgb(195, 232, 250); 
-        border: 1px solid #9fbcc5;
-        border-radius: 4px;
-        padding: 0.5rem
+        position: absolute;
+        color: #fff;
+    }
 
-        &:hover {
-            cursor: pointer;
-            background-color: rgba(208, 238, 249, 0.87);
-        }
+    .chapter-1-text {
+        left: 42%;
+        top: 20%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
+    }
 
-        &.disabled {
-            color: #001533;
-            cursor: not-allowed;
-            background-color:rgb(48, 119, 219); 
-        }
-    
-        +portrait() {
-            font-size: 0.8rem;
-            padding: 0.1rem;
-            width: 60%;
-            margin-left: auto;
-            margin-right: auto;
-        }
+    .chapter-2-text {
+        right: 15%;
+        top: 30%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
+    }
+
+    .chapter-3-text {
+        right: 8%;
+        top: 55%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
+    }
+
+    .chapter-4-text {
+        right: 19%;
+        bottom: 17%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
+    }
+
+    .chapter-5-text {
+        left: 44%;
+        bottom: 6%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
+    }
+    .chapter-6-text {
+        left: 20%;
+        bottom: 17%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
+    }
+    .chapter-7-text {
+        left: 10%;
+        top: 55%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
+    }
+    .chapter-8-text {
+        left: 20%;
+        top: 30%;
+        color: rgb(255, 204, 102);
+        font-weight: bold;
+        text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px  1px 0 #000,
+         1px  1px 0 #000;
+         background-color: white;
+         padding: 5px;
+         border-radius: 15px;
     }
 }

--- a/src/views/LearnToPlay/LearnToPlay.tsx
+++ b/src/views/LearnToPlay/LearnToPlay.tsx
@@ -43,7 +43,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-1-container">
                         <ChapterButton chapter={1} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-1-text"
                             onClick={() => navigateToChapter(1, navigate)}
                         >
                             Capturing Stones
@@ -53,7 +53,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-2-container">
                         <ChapterButton chapter={2} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-2-text"
                             onClick={() => navigateToChapter(2, navigate)}
                         >
                             Quest for Space
@@ -64,7 +64,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-3-container">
                         <ChapterButton chapter={3} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-3-text"
                             onClick={() => navigateToChapter(3, navigate)}
                         >
                             Eyes for Life
@@ -74,7 +74,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-4-container">
                         <ChapterButton chapter={4} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-4-text"
                             onClick={() => navigateToChapter(4, navigate)}
                         >
                             Ko Battles
@@ -84,7 +84,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-5-container">
                         <ChapterButton chapter={5} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-5-text"
                             onClick={() => navigateToChapter(5, navigate)}
                         >
                             Magic Moves
@@ -94,7 +94,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-6-container">
                         <ChapterButton chapter={6} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-6-text"
                             onClick={() => navigateToChapter(6, navigate)}
                         >
                             Connecting
@@ -104,7 +104,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-7-container">
                         <ChapterButton chapter={7} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-7-text"
                             onClick={() => navigateToChapter(7, navigate)}
                         >
                             Scoring
@@ -114,7 +114,7 @@ export function LearnToPlay(): JSX.Element {
                     <div className="chapter-container chapter-8-container">
                         <ChapterButton chapter={8} />
                         <div
-                            className="chapter-text"
+                            className="chapter-text chapter-8-text"
                             onClick={() => navigateToChapter(8, navigate)}
                         >
                             Problems

--- a/src/views/LearnToPlay/LearnToPlay.tsx
+++ b/src/views/LearnToPlay/LearnToPlay.tsx
@@ -46,7 +46,7 @@ export function LearnToPlay(): JSX.Element {
                             className="chapter-text"
                             onClick={() => navigateToChapter(1, navigate)}
                         >
-                            Capturing
+                            Capturing Stones
                         </div>
                     </div>
 
@@ -56,7 +56,7 @@ export function LearnToPlay(): JSX.Element {
                             className="chapter-text"
                             onClick={() => navigateToChapter(2, navigate)}
                         >
-                            Territory
+                            Quest for Space
                         </div>
                     </div>
 
@@ -67,7 +67,7 @@ export function LearnToPlay(): JSX.Element {
                             className="chapter-text"
                             onClick={() => navigateToChapter(3, navigate)}
                         >
-                            Eyes
+                            Eyes for Life
                         </div>
                     </div>
 
@@ -77,7 +77,7 @@ export function LearnToPlay(): JSX.Element {
                             className="chapter-text"
                             onClick={() => navigateToChapter(4, navigate)}
                         >
-                            Ko
+                            Ko Battles
                         </div>
                     </div>
 
@@ -87,7 +87,7 @@ export function LearnToPlay(): JSX.Element {
                             className="chapter-text"
                             onClick={() => navigateToChapter(5, navigate)}
                         >
-                            Reading
+                            Magic Moves
                         </div>
                     </div>
 

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -673,9 +673,13 @@ class Puzzle4 extends Module1 {
 }
 
 class Puzzle5 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472327/audio-slices-less-pauses/slice14_less_pauses_if00pt.wav",
+        );
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -704,6 +708,9 @@ class Puzzle5 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Good job!</Axol>,
@@ -738,9 +745,13 @@ class Puzzle5 extends Module1 {
 }
 
 class Puzzle6 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -769,6 +780,9 @@ class Puzzle6 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>You did it!</Axol>,
@@ -803,9 +817,13 @@ class Puzzle6 extends Module1 {
 }
 
 class Puzzle7 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852117/kids-go-server-audio-slices/slice_17_z0n55r.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -834,6 +852,9 @@ class Puzzle7 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Nice work!</Axol>,
@@ -868,9 +889,13 @@ class Puzzle7 extends Module1 {
 }
 
 class Puzzle8 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -899,6 +924,9 @@ class Puzzle8 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -46,6 +46,11 @@ class Module1 extends Content {
             audio.pause();
             audio.currentTime = 0;
         }
+        // Clean up the delay of stone animations, otherwise it'll persist across rerenders and cause weird side effects
+        Object.keys(this.delays).forEach((key) => {
+            clearTimeout(this.delays[key]);
+            delete this.delays[key];
+        });
     }
 }
 

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -41,7 +41,6 @@ class Module1 extends Content {
     };
 
     componentWillUnmount() {
-        // Stop audio playback and cleanup when the component is about to unmount
         const audio = this.audioRef.current;
         if (audio) {
             audio.pause();
@@ -55,7 +54,6 @@ class Page1 extends Module1 {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854748/kids-go-server-COMBINED-audio-slices/slice_audio1_nkvkon.wav",
         );
-        console.log("Page1 constructor");
     }
 
     text(): JSX.Element | Array<JSX.Element> {
@@ -70,11 +68,11 @@ class Page1 extends Module1 {
                 autoPlay={true} // This line auto plays the audio when we click the next button to navigate to the next page
                 src={this.audioUrl}
             ></audio>,
-            <span>In Go we place stones on the lines, not in the squares!</span>,
-            <span>
+            <p>In Go we place stones on the lines, not in the squares!</p>,
+            <p>
                 The darker color, Blast Off Blue in this case, always goes first, followed by the
                 lighter color, Whammo White here.
-            </span>,
+            </p>,
         ];
     }
     config(): PuzzleConfig {
@@ -100,7 +98,6 @@ class Page2 extends Module1 {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854682/kids-go-server-COMBINED-audio-slices/slice_audio2_pcjrth.wav",
         );
-        console.log("page 2 constructor");
     }
 
     text(): JSX.Element | Array<JSX.Element> {

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -24,20 +24,57 @@ import { openPopup } from "@kidsgo/components/PopupDialog";
 const POPUP_TIMEOUT = 1500;
 
 class Module1 extends Content {
-    constructor() {
+    audioRef: React.RefObject<HTMLAudioElement>;
+    audioUrl: string;
+
+    constructor(audioUrl: string) {
         super();
+        this.audioRef = React.createRef();
+        this.audioUrl = audioUrl;
+    }
+
+    playAudio = async () => {
+        const audio = this.audioRef.current;
+        if (audio) {
+            await audio.play();
+        }
+    };
+
+    componentWillUnmount() {
+        // Stop audio playback and cleanup when the component is about to unmount
+        const audio = this.audioRef.current;
+        if (audio) {
+            audio.pause();
+            audio.currentTime = 0;
+        }
     }
 }
 
 class Page1 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854748/kids-go-server-COMBINED-audio-slices/slice_audio1_nkvkon.wav",
+        );
+        console.log("Page1 constructor");
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <p>In Go we place stones on the lines, not in the squares!</p>,
-            <p>
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true} // This line auto plays the audio when we click the next button to navigate to the next page
+                src={this.audioUrl}
+            ></audio>,
+            <span>In Go we place stones on the lines, not in the squares!</span>,
+            <span>
                 The darker color, Blast Off Blue in this case, always goes first, followed by the
                 lighter color, Whammo White here.
-            </p>,
-            <p>Use the next arrow in the bottom right to continue.</p>,
+            </span>,
         ];
     }
     config(): PuzzleConfig {
@@ -59,8 +96,25 @@ class Page1 extends Module1 {
 }
 
 class Page2 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854682/kids-go-server-COMBINED-audio-slices/slice_audio2_pcjrth.wav",
+        );
+        console.log("page 2 constructor");
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 The spaces next to the stones are important, we call them Liberties. This stone has
                 four liberties where the lines cross.
@@ -87,8 +141,24 @@ class Page2 extends Module1 {
 }
 
 class Page3 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854677/kids-go-server-COMBINED-audio-slices/slice_audio3_n7porg.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 There are no liberties off the edge of the board, so this stone only has two
                 liberties.
@@ -111,8 +181,26 @@ class Page3 extends Module1 {
 }
 
 class Page4 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854678/kids-go-server-COMBINED-audio-slices/slice_audio4_xitqmt.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>And this stone only has three.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>And this stone only has three.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -131,8 +219,23 @@ class Page4 extends Module1 {
 }
 
 class Page5 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854684/kids-go-server-COMBINED-audio-slices/slice_audio5_l4jolv.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Stones of the same color that touch each other are on the same team. So they share
                 their liberties.
@@ -161,8 +264,23 @@ class Page5 extends Module1 {
 }
 
 class Page6 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854745/kids-go-server-COMBINED-audio-slices/slice_audio6_hpjrch.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 If the other player takes 3 out of 4 liberties, we say a stone is in Atari, which
                 means it can be captured on the next turn.
@@ -187,8 +305,23 @@ class Page6 extends Module1 {
 }
 
 class Page7 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854750/kids-go-server-COMBINED-audio-slices/slice_audio7_cflubx.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>If we add a stone, then they form a team and get new liberties.</p>,
             <p>Now they have three liberties and are safe from immediate capture.</p>,
         ];
@@ -211,8 +344,23 @@ class Page7 extends Module1 {
 }
 
 class Page8 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707854685/kids-go-server-COMBINED-audio-slices/slice_audio8_d4znwa.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 If Blue goes somewhere else though, then White can capture the stone and remove it
                 from the board.
@@ -236,8 +384,27 @@ class Page8 extends Module1 {
 }
 
 class Puzzle1 extends Module1 {
+    constructor() {
+        // This is the manually sliced audio clip for the first puzzle
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707977976/kids-go-server-audio-slices/slice_first_puzzle_audio_wflxs8.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Lets try some simple problems now. Try and capture the White stone.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Lets try some simple problems now. Try and capture the White stone.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -284,8 +451,25 @@ class Puzzle1 extends Module1 {
 }
 
 class Puzzle2 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852119/kids-go-server-audio-slices/slice_14_s6dmem.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Try and capture the White stone.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Try and capture the White stone.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -332,8 +516,25 @@ class Puzzle2 extends Module1 {
 }
 
 class Puzzle3 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852118/kids-go-server-audio-slices/slice_16_p8yhmr.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Try and capture the White stones.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Try and capture the White stones.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -380,8 +581,25 @@ class Puzzle3 extends Module1 {
 }
 
 class Puzzle4 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Try and capture these White stones.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Try and capture these White stones.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -428,8 +646,25 @@ class Puzzle4 extends Module1 {
 }
 
 class Puzzle5 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472327/audio-slices-less-pauses/slice14_less_pauses_if00pt.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Try and capture the White stone.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Try and capture the White stone.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -476,8 +711,25 @@ class Puzzle5 extends Module1 {
 }
 
 class Puzzle6 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Try and capture these White stones.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Try and capture these White stones.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -524,8 +776,25 @@ class Puzzle6 extends Module1 {
 }
 
 class Puzzle7 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Try and capture these White stones.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Try and capture these White stones.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -572,8 +841,25 @@ class Puzzle7 extends Module1 {
 }
 
 class Puzzle8 extends Module1 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Try and capture these White stones.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Try and capture these White stones.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -46,11 +46,6 @@ class Module1 extends Content {
             audio.pause();
             audio.currentTime = 0;
         }
-        // Clean up the delay of stone animations, otherwise it'll persist across rerenders and cause weird side effects
-        Object.keys(this.delays).forEach((key) => {
-            clearTimeout(this.delays[key]);
-            delete this.delays[key];
-        });
     }
 }
 

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -679,7 +679,7 @@ class Puzzle5 extends Module1 {
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472327/audio-slices-less-pauses/slice14_less_pauses_if00pt.wav",
         );
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.wav",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852115/kids-go-server-audio-slices/slice_13_q0v6nw.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -751,7 +751,7 @@ class Puzzle6 extends Module1 {
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
         );
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.wav",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852116/kids-go-server-audio-slices/slice_15_cidisp.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -381,10 +381,15 @@ class Page8 extends Module1 {
 }
 
 class Puzzle1 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         // This is the manually sliced audio clip for the first puzzle
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707977976/kids-go-server-audio-slices/slice_first_puzzle_audio_wflxs8.wav",
+        );
+        // Success audio for the popup audio!  Says "Good job!"
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852115/kids-go-server-audio-slices/slice_13_q0v6nw.wav",
         );
     }
 
@@ -414,6 +419,10 @@ class Puzzle1 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            // If we chain the success audio after the captureDelay, the "good job audio clip" happens after we go to the next puzzle
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Good job!</Axol>,
@@ -448,9 +457,13 @@ class Puzzle1 extends Module1 {
 }
 
 class Puzzle2 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852119/kids-go-server-audio-slices/slice_14_s6dmem.wav",
+        );
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852116/kids-go-server-audio-slices/slice_15_cidisp.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -479,6 +492,9 @@ class Puzzle2 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>You did it!</Axol>,
@@ -513,9 +529,13 @@ class Puzzle2 extends Module1 {
 }
 
 class Puzzle3 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852118/kids-go-server-audio-slices/slice_16_p8yhmr.wav",
+        );
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852117/kids-go-server-audio-slices/slice_17_z0n55r.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -544,6 +564,9 @@ class Puzzle3 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Nice work!</Axol>,
@@ -578,9 +601,13 @@ class Puzzle3 extends Module1 {
 }
 
 class Puzzle4 extends Module1 {
+    private successAudio: HTMLAudioElement;
     constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.wav",
+        );
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1707852119/kids-go-server-audio-slices/slice_19_ddyawc.wav",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -609,6 +636,9 @@ class Puzzle4 extends Module1 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -49,8 +49,23 @@ class Module2 extends Content {
 }
 
 class Page1 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708550145/audio-slices-less-pauses/slice20_less_pauses_revised_wlyinf.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <span>
                 Based on the last lesson you might think the goal of this game is to capture stones,
                 but actually whoever surrounds the most territory at the end of the game wins.
@@ -69,8 +84,23 @@ class Page1 extends Module2 {
 }
 
 class Page2 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708550225/audio-slices-less-pauses/slice21_less_pauses_revised_vjtr4g.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Territory is the empty space we surround. Here is one kind of territory using the
                 edge of the board. There are four points of territory in the corner.
@@ -97,8 +127,23 @@ class Page2 extends Module2 {
 }
 
 class Page3 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708550312/audio-slices-less-pauses/slice22_less_pauses_revised_ksy8ir.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Here is another kind of territory, made by surrounding space in the middle. How many
                 points of territory does Blue have here?
@@ -117,8 +162,25 @@ class Page3 extends Module2 {
 }
 
 class Page4 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472337/audio-slices-less-pauses/slice23_less_pauses_sr0s2s.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Four points is right.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Four points is right.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -138,8 +200,25 @@ class Page4 extends Module2 {
 }
 
 class Page5 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472339/audio-slices-less-pauses/slice24_less_pauses_woik4b.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>How many points does Blue have here?</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>How many points does Blue have here?</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -155,8 +234,23 @@ class Page5 extends Module2 {
 }
 
 class Page6 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708550675/audio-slice-less-pauses-COMBINED/slice25_and_26_combined_xjrc9k.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>The answer is 9 points for Blue.</p>,
             <p>Remember, you only need to build your fence up to the edge of the board. </p>,
         ];
@@ -186,8 +280,23 @@ class Page6 extends Module2 {
 }
 
 class Page7 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472343/audio-slices-less-pauses/slice27_less_pauses_mkkli5.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 In Go, we play until the two colors are touching each other, and the empty space
                 each blocks off and surrounds is their territory.
@@ -208,8 +317,23 @@ class Page7 extends Module2 {
 }
 
 class Page8 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708552000/audio-slice-less-pauses-COMBINED/slice28_29_and_30_combined_go49dz.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>Can White play on Blue's side? Yes.</p>,
             <p>Can Blue play on White's side? Yes.</p>,
             <p>
@@ -243,8 +367,23 @@ class Page8 extends Module2 {
 // the game ends and we score the game or something. Or something like "when you think the game is over, say "pass", if your opponent also thinks the game is over, they can say
 // "pass" too, then we can score the game!
 class Page9 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708552553/audio-slice-less-pauses-COMBINED/slice31_and_32_combined_jcmxoh.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 If you think the game is over, just pass a stone to your opponent. If your opponent
                 plays a stone then you can either play or pass.
@@ -269,8 +408,23 @@ class Page9 extends Module2 {
 }
 
 class Page10 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708552711/audio-slice-less-pauses-COMBINED/slice33_and_34_combined_bkl2un.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>Blue has territory on the left, and White has it on the right.</p>,
             <p>We can see Blue has 23 points.</p>,
         ];
@@ -295,8 +449,25 @@ class Page10 extends Module2 {
 }
 
 class Page11 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472354/audio-slices-less-pauses/slice35_less_pauses_pzy4sf.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>And White has 24, so White is ahead by one.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>And White has 24, so White is ahead by one.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -318,8 +489,23 @@ class Page11 extends Module2 {
 }
 
 class Page12 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708553650/audio-slice-less-pauses-COMBINED/slice36_38_and_39_combined_kymjby.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>But Blue also captured three stones which went into the prisoner bowl.</p>,
             <p>Those three stones that Blue captured are subtracted from White's territory.</p>,
             <p>Now the score is Blue 23 and White 21 so Blue wins by two.</p>,
@@ -343,8 +529,23 @@ class Page12 extends Module2 {
 }
 
 class Page13 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472581/audio-slices-less-pauses/slice39_less_pauses_t7eggo.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 When we play face-to-face we put all captures back into the territory of the same
                 color. So at the end of the game, the board will have all the stones played during

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -562,6 +562,11 @@ class Page13 extends Module2 {
 }
 
 class Page14 extends Module2 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1746213981/lets_try_some_simple_problems_now_audio_snipped_5_2_2025_lbpyvj.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Let's try some simple problems now.</p>];
     }
@@ -574,6 +579,13 @@ class Page14 extends Module2 {
 }
 
 class Puzzle1 extends Module2 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547864/audio-slices-less-pauses/slice13_less_pauses_revised_tanua8.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the Blue stones.</p>];
     }
@@ -588,6 +600,9 @@ class Puzzle1 extends Module2 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Good job!</Axol>,
@@ -622,6 +637,13 @@ class Puzzle1 extends Module2 {
 }
 
 class Puzzle2 extends Module2 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Capture the 2 White stones.</p>];
     }
@@ -636,6 +658,9 @@ class Puzzle2 extends Module2 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>You did it!</Axol>,
@@ -670,6 +695,13 @@ class Puzzle2 extends Module2 {
 }
 
 class Puzzle3 extends Module2 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472331/audio-slices-less-pauses/slice17_less_pauses_znln8h.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Capture the 5 White stones.</p>];
     }
@@ -684,6 +716,9 @@ class Puzzle3 extends Module2 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Nice work!</Axol>,
@@ -718,6 +753,13 @@ class Puzzle3 extends Module2 {
 }
 
 class Puzzle4 extends Module2 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the 3 Blue stones.</p>];
     }
@@ -735,6 +777,9 @@ class Puzzle4 extends Module2 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
@@ -769,6 +814,13 @@ class Puzzle4 extends Module2 {
 }
 
 class Puzzle5 extends Module2 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547864/audio-slices-less-pauses/slice13_less_pauses_revised_tanua8.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the 2 Blue stones.</p>];
     }
@@ -786,6 +838,9 @@ class Puzzle5 extends Module2 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Good job!</Axol>,
@@ -820,6 +875,13 @@ class Puzzle5 extends Module2 {
 }
 
 class Puzzle6 extends Module2 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Capture the 3 White stones.</p>];
     }
@@ -837,6 +899,9 @@ class Puzzle6 extends Module2 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>You did it!</Axol>,
@@ -871,6 +936,13 @@ class Puzzle6 extends Module2 {
 }
 
 class Puzzle7 extends Module2 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the 7 Blue stones, this one is very tricky!</p>];
     }
@@ -905,6 +977,9 @@ class Puzzle7 extends Module2 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -66,10 +66,10 @@ class Page1 extends Module2 {
                 autoPlay={true}
                 src={this.audioUrl}
             ></audio>,
-            <span>
+            <p>
                 Based on the last lesson you might think the goal of this game is to capture stones,
                 but actually whoever surrounds the most territory at the end of the game wins.
-            </span>,
+            </p>,
         ];
     }
     config(): PuzzleConfig {

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -23,8 +23,28 @@ import { openPopup } from "@kidsgo/components/PopupDialog";
 
 const POPUP_TIMEOUT = 1500;
 class Module2 extends Content {
-    constructor() {
+    audioRef: React.RefObject<HTMLAudioElement>;
+    audioUrl: string;
+
+    constructor(audioUrl: string) {
         super();
+        this.audioRef = React.createRef();
+        this.audioUrl = audioUrl;
+    }
+
+    playAudio = async () => {
+        const audio = this.audioRef.current;
+        if (audio) {
+            await audio.play();
+        }
+    };
+
+    componentWillUnmount() {
+        const audio = this.audioRef.current;
+        if (audio) {
+            audio.pause();
+            audio.currentTime = 0;
+        }
     }
 }
 

--- a/src/views/Lessons/Module3.tsx
+++ b/src/views/Lessons/Module3.tsx
@@ -23,14 +23,50 @@ import { openPopup } from "@kidsgo/components/PopupDialog";
 
 const POPUP_TIMEOUT = 1500;
 class Module3 extends Content {
-    constructor() {
+    audioRef: React.RefObject<HTMLAudioElement>;
+    audioUrl: string;
+
+    constructor(audioUrl: string) {
         super();
+        this.audioRef = React.createRef();
+        this.audioUrl = audioUrl;
+    }
+
+    playAudio = async () => {
+        const audio = this.audioRef.current;
+        if (audio) {
+            await audio.play();
+        }
+    };
+
+    componentWillUnmount() {
+        const audio = this.audioRef.current;
+        if (audio) {
+            audio.pause();
+            audio.currentTime = 0;
+        }
     }
 }
 
 class Page1 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708554656/audio-slice-less-pauses-COMBINED/slice45_and_48_combined_dgsntg.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 One of the few rules in Go is that any stone played must have at least one liberty
                 after it's played.
@@ -56,8 +92,24 @@ class Page1 extends Module3 {
 }
 
 class Page2 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708554818/audio-slices-less-pauses/slice46_less_pauses_revised_npgupt.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Now notice that this group has been completely closed in on the outside, although it
                 does still have liberties inside.
@@ -76,8 +128,24 @@ class Page2 extends Module3 {
 }
 
 class Page3 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472373/audio-slices-less-pauses/slice45_less_pauses_qcmti9.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 If it's Blue's turn, a play in the middle will create a group with two separate
                 liberties inside. These are called eyes, and this group has two of them.
@@ -99,8 +167,24 @@ class Page3 extends Module3 {
 }
 
 class Page4 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472580/audio-slices-less-pauses/slice47_less_pauses_oddmrp.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 White cannot play at either of the triangled points here, so Blue can never come
                 into atari. A group like this can not be captured because it has two eyes.
@@ -122,8 +206,26 @@ class Page4 extends Module3 {
 }
 
 class Page5 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472377/audio-slices-less-pauses/slice48_less_pauses_l10z1c.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>What happens if White gets to play in the middle first?</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>What happens if White gets to play in the middle first?</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -143,8 +245,24 @@ class Page5 extends Module3 {
 }
 
 class Page6 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472379/audio-slices-less-pauses/slice49_less_pauses_i2uwkz.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 If Blue tries to capture the stone by playing at 2, notice that all the Blue stones
                 are now in atari at A.
@@ -171,8 +289,23 @@ class Page6 extends Module3 {
 }
 
 class Page7 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708555182/audio-slice-less-pauses-COMBINED/slice52_53_and_54_combined_idgmba.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>It looks like White can't play at A because the team would have no liberties.</p>,
             <p>But playing at A captures six Blue stones first giving White three liberties.</p>,
             <p>Remember, any stone played must have liberties at the end of the turn.</p>,
@@ -201,8 +334,24 @@ class Page7 extends Module3 {
 }
 
 class Page8 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472586/audio-slices-less-pauses/slice53_less_pauses_smoepq.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 So a Blue play at A is obviously not a good move. It takes one of Blue's liberties.
                 And playing at B would also put Blue's group into atari.
@@ -225,8 +374,24 @@ class Page8 extends Module3 {
 }
 
 class Page9 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708555395/audio-slice-less-pauses-COMBINED/slice54_and_57_combined_fhlma2.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 So perhaps Blue decides not to play at either point. The group is not in atari, so
                 what can White do anyway? Well, White can play at 1...
@@ -251,8 +416,24 @@ class Page9 extends Module3 {
 }
 
 class Page10 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472590/audio-slices-less-pauses/slice56_less_pauses_myxeli.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Now Blue is again in atari, and White could capture by playing at A. But wait, White
                 is in atari too...
@@ -274,8 +455,26 @@ class Page10 extends Module3 {
 }
 
 class Page11 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472582/audio-slices-less-pauses/slice57_less_pauses_ksavic.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>So Blue can capture two stones with 1. Surely the group is okay now.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>So Blue can capture two stones with 1. Surely the group is okay now.</p>,
+            <p>So Blue can capture two stones with 1. Surely the group is okay now.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -297,8 +496,23 @@ class Page11 extends Module3 {
 }
 
 class Page12 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708555523/audio-slices-less-pauses/slice60_less_pauses_revised_wseie1.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 What happens if White plays at 2? It's true, White is also in atari, so Blue can
                 capture again...
@@ -333,8 +547,23 @@ class Page12 extends Module3 {
 }
 
 class Page13 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708555614/audio-slices-less-pauses/slice61_less_pauses_revised_ptlzux.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 But now the Blue group only has a single liberty, which means White can capture
                 seven stones at once. Ouch!
@@ -360,8 +589,23 @@ class Page13 extends Module3 {
 }
 
 class Page14 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472596/audio-slices-less-pauses/slice60_less_pauses_vlwhff.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Looking again, we see that the placement of a single stone can make all the
                 difference. Playing at A is the key point for both sides.
@@ -383,8 +627,23 @@ class Page14 extends Module3 {
 }
 
 class Page15 extends Module3 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472583/audio-slices-less-pauses/slice61_less_pauses_fh5hpq.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>Good job learning about eyes so far, this is tricky stuff!</p>,
 
             <p>Let's have some simple life and death puzzles now.</p>,

--- a/src/views/Lessons/Module3.tsx
+++ b/src/views/Lessons/Module3.tsx
@@ -658,6 +658,13 @@ class Page15 extends Module3 {
 }
 
 class Puzzle1 extends Module3 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547864/audio-slices-less-pauses/slice13_less_pauses_revised_tanua8.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Capture the White stones.</p>];
     }
@@ -672,6 +679,9 @@ class Puzzle1 extends Module3 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Good job!</Axol>,
@@ -706,6 +716,13 @@ class Puzzle1 extends Module3 {
 }
 
 class Puzzle2 extends Module3 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the Blue stones.</p>];
     }
@@ -720,6 +737,9 @@ class Puzzle2 extends Module3 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>You did it!</Axol>,
@@ -754,6 +774,13 @@ class Puzzle2 extends Module3 {
 }
 
 class Puzzle3 extends Module3 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472331/audio-slices-less-pauses/slice17_less_pauses_znln8h.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the Blue stones.</p>];
     }
@@ -768,6 +795,9 @@ class Puzzle3 extends Module3 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Nice work!</Axol>,
@@ -802,6 +832,13 @@ class Puzzle3 extends Module3 {
 }
 
 class Puzzle4 extends Module3 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the Blue stones.</p>];
     }
@@ -816,6 +853,9 @@ class Puzzle4 extends Module3 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
@@ -850,6 +890,13 @@ class Puzzle4 extends Module3 {
 }
 
 class Puzzle5 extends Module3 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547864/audio-slices-less-pauses/slice13_less_pauses_revised_tanua8.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Capture the White stones.</p>];
     }
@@ -864,6 +911,9 @@ class Puzzle5 extends Module3 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Good job!</Axol>,
@@ -898,6 +948,13 @@ class Puzzle5 extends Module3 {
 }
 
 class Puzzle6 extends Module3 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the Blue stones.</p>];
     }
@@ -912,6 +969,9 @@ class Puzzle6 extends Module3 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>You did it!</Axol>,
@@ -946,6 +1006,13 @@ class Puzzle6 extends Module3 {
 }
 
 class Puzzle7 extends Module3 {
+    private successAudio: HTMLAudioElement;
+    constructor() {
+        super("no_audio_here");
+        this.successAudio = new Audio(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472331/audio-slices-less-pauses/slice17_less_pauses_znln8h.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [<p>Save the Blue stones.</p>];
     }
@@ -963,6 +1030,9 @@ class Puzzle7 extends Module3 {
     }
     onSetGoban(goban: Goban): void {
         goban.on("puzzle-correct-answer", () => {
+            this.successAudio
+                .play()
+                .catch((error) => console.error("Error playing success audio:", error));
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Nice work!</Axol>,

--- a/src/views/Lessons/Module4.tsx
+++ b/src/views/Lessons/Module4.tsx
@@ -20,14 +20,49 @@ import { Content } from "./Content";
 import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 
 class Module4 extends Content {
-    constructor() {
+    audioRef: React.RefObject<HTMLAudioElement>;
+    audioUrl: string;
+
+    constructor(audioUrl: string) {
         super();
+        this.audioRef = React.createRef();
+        this.audioUrl = audioUrl;
+    }
+
+    playAudio = async () => {
+        const audio = this.audioRef.current;
+        if (audio) {
+            await audio.play();
+        }
+    };
+
+    componentWillUnmount() {
+        const audio = this.audioRef.current;
+        if (audio) {
+            audio.pause();
+            audio.currentTime = 0;
+        }
     }
 }
 
 class Page1 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708636014/audio-slices-less-pauses/slice64_less_pauses_revised_lppayu.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Here's a situation that sometimes comes up. Notice that the White stone at A is in
                 atari?
@@ -49,8 +84,24 @@ class Page1 extends Module4 {
 }
 
 class Page2 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708636318/audio-slice-less-pauses-COMBINED/slice65_and_66_combined_j2mjda.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>Since Blue is capturing a stone and getting a liberty, playing at B is allowed.</p>,
             <p>But now Blue is in atari...</p>,
         ];
@@ -70,8 +121,23 @@ class Page2 extends Module4 {
 }
 
 class Page3 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708636476/audio-slices-less-pauses/slice67_less_pauses_revised_hg7s10.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>So White could play at A again and capture Blue. But now White is in atari...</p>,
         ];
     }
@@ -90,8 +156,24 @@ class Page3 extends Module4 {
 }
 
 class Page4 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708636656/audio-slice-less-pauses-COMBINED/slice68_69_and_70combined_ffqsh6.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>So Blue could capture, but then would be in atari again...</p>,
             <p>This could go on forever, so there is a special rule to cover it.</p>,
             <p>
@@ -115,8 +197,23 @@ class Page4 extends Module4 {
 }
 
 class Page5 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708636813/audio-slices-less-pauses/slice71_less_pauses_revised_e95kry.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 So the first player to capture in a position like this starts what is called a "ko".
                 On this board, Blue would start a ko by capturing at 1.
@@ -138,8 +235,23 @@ class Page5 extends Module4 {
 }
 
 class Page6 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472600/audio-slices-less-pauses/slice70_less_pauses_obbwtz.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 The ko rule prevents a player from immediately recapturing. That would repeat the
                 board. But it only affects the first move after a capture.
@@ -162,8 +274,24 @@ class Page6 extends Module4 {
 }
 
 class Page7 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708637273/audio-slice-less-pauses-COMBINED/slice73_and_74_combined_mscsc1.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 So White can play anywhere on the board except at the triangled point. Perhaps White
                 will play at 2, and then Blue might play at say, 3.
@@ -199,8 +327,24 @@ class Page7 extends Module4 {
 }
 
 class Page8 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472604/audio-slices-less-pauses/slice73_less_pauses_k2puq1.wav",
+        );
+    }
+
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Since the board has changed, a play at A is allowed. Now it’s Blue's turn to be
                 caught by the rule of ko. Blue can play anywhere except the triangled point.
@@ -225,8 +369,23 @@ class Page8 extends Module4 {
 }
 
 class Page9 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472598/audio-slices-less-pauses/slice74_less_pauses_tsdqt4.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>So perhaps Blue will play at 1 to connect two stones and prevent a cut by White.</p>,
         ];
     }
@@ -246,8 +405,23 @@ class Page9 extends Module4 {
 }
 
 class Page10 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472612/audio-slices-less-pauses/slice75_less_pauses_d1dylj.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 If White thinks the ko is more important, it can be filled in with 2. In this case,
                 Blue actually gets a good solid position by playing at 3. So each side got
@@ -272,8 +446,23 @@ class Page10 extends Module4 {
 }
 
 class Page11 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708637886/audio-slices-less-pauses/slice78_less_pauses_revised_tyedip.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Sometimes winning the ko can affect the life of a whole group. If Blue can capture
                 and then fill the ko at A, the group will make two eyes. If White wins, all the Blue
@@ -296,8 +485,23 @@ class Page11 extends Module4 {
 }
 
 class Page12 extends Module4 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708637983/audio-slices-less-pauses/slice79_less_pauses_revised_m0msdr.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Sometimes a ko is meaningless and only affects the stone in atari. Don't worry about
                 ko too much for right now, just start playing some games and you'll learn more as

--- a/src/views/Lessons/Module5.tsx
+++ b/src/views/Lessons/Module5.tsx
@@ -20,14 +20,49 @@ import { Content } from "./Content";
 import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 
 class Module5 extends Content {
-    constructor() {
+    audioRef: React.RefObject<HTMLAudioElement>;
+    audioUrl: string;
+
+    constructor(audioUrl: string) {
         super();
+        this.audioRef = React.createRef();
+        this.audioUrl = audioUrl;
+    }
+
+    playAudio = async () => {
+        const audio = this.audioRef.current;
+        if (audio) {
+            await audio.play();
+        }
+    };
+
+    componentWillUnmount() {
+        const audio = this.audioRef.current;
+        if (audio) {
+            audio.pause();
+            audio.currentTime = 0;
+        }
     }
 }
 
 class Page1 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472606/audio-slices-less-pauses/slice78_less_pauses_k9xkqa.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>Here's an example of how some things might play out in a real game.</p>,
             <p>
                 Let's look at these two stones. They're not a team, because diagonal points are not
@@ -48,8 +83,23 @@ class Page1 extends Module5 {
 }
 
 class Page2 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472607/audio-slices-less-pauses/slice79_less_pauses_srqee7.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 With enough moves, both stones could be captured. The White stone at 1 places both
                 Blue stones into atari at once, or double atari.
@@ -73,8 +123,25 @@ class Page2 extends Module5 {
 }
 
 class Page3 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472601/audio-slices-less-pauses/slice80_less_pauses_v0jd9a.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Blue could add a stone at 2 to make a group with three liberties.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Blue could add a stone at 2 to make a group with three liberties.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -101,8 +168,23 @@ class Page3 extends Module5 {
 }
 
 class Page4 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472600/audio-slices-less-pauses/slice81_less_pauses_wvf1ee.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 White can still capture the other stone at 3 though, because it's not connected to
                 the Blue group.
@@ -128,8 +210,23 @@ class Page4 extends Module5 {
 }
 
 class Page5 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472608/audio-slices-less-pauses/slice82_less_pauses_ikjoo1.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 So White might try to capture the Blue group by adding a stone at 1. Blue might try
                 playing at 2 to save the stones.
@@ -158,8 +255,23 @@ class Page5 extends Module5 {
 }
 
 class Page6 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708639605/audio-slices-less-pauses/slice85_less_pauses_revised_dgu07k.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Maybe White gets impatient and tries to surround Blue's group with 3. Blue responds
                 with 4, which puts White's stone at A into atari.
@@ -198,8 +310,23 @@ class Page6 extends Module5 {
 }
 
 class Page7 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708638936/audio-slice-less-pauses-COMBINED/slice86_and_87_combined_ct8ryr.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 White will lose the stone at A if Blue plays at B, so White adds a stone there to
                 get new liberties.
@@ -224,8 +351,23 @@ class Page7 extends Module5 {
 }
 
 class Page8 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472602/audio-slices-less-pauses/slice86_less_pauses_srkqgo.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>Now Blue has turned the tables on White! Playing at 1 puts White C into atari.</p>,
         ];
     }
@@ -247,8 +389,23 @@ class Page8 extends Module5 {
 }
 
 class Page9 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708639046/audio-slices-less-pauses/slice89_less_pauses_revised_llnh9k.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 White adds a stone at 2, but there's a problem. 2 is on the edge of the board, which
                 means there is one liberty less!
@@ -273,8 +430,23 @@ class Page9 extends Module5 {
 }
 
 class Page10 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472610/audio-slices-less-pauses/slice88_less_pauses_f7u8uy.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 This means that a move by Blue at either A or B will put two White stones into
                 atari. Which one do you think is best?
@@ -299,8 +471,23 @@ class Page10 extends Module5 {
 }
 
 class Page11 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472603/audio-slices-less-pauses/slice89_less_pauses_ahaovx.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Let's look at B first. This move looks good because on the next turn Blue could
                 capture the two White stones at A.
@@ -325,8 +512,23 @@ class Page11 extends Module5 {
 }
 
 class Page12 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472620/audio-slices-less-pauses/slice90_less_pauses_tb5ayg.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Unfortunately, it's not Blue's turn. While it is true that White is in atari, Blue
                 is also now in atari, so White can capture first - at C - and remove four Blue
@@ -359,8 +561,23 @@ class Page12 extends Module5 {
 }
 
 class Page13 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708639218/audio-slices-less-pauses/slice93_less_pauses_revised_muwwqy.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 Let's try going the other way this time. A Blue play at A also puts the two White
                 stones into atari.
@@ -384,8 +601,25 @@ class Page13 extends Module5 {
 }
 
 class Page14 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472612/audio-slices-less-pauses/slice92_less_pauses_vqjtar.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Now even if White adds a stone at 2, which puts Blue into atari at D...</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>Now even if White adds a stone at 2, which puts Blue into atari at D...</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -406,8 +640,25 @@ class Page14 extends Module5 {
 }
 
 class Page15 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472617/audio-slices-less-pauses/slice93_less_pauses_sxisdv.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>It's now Blue's turn, and playing at D captures all three White stones.</p>];
+        return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
+            <p>It's now Blue's turn, and playing at D captures all three White stones.</p>,
+        ];
     }
     config(): PuzzleConfig {
         return {
@@ -431,8 +682,23 @@ class Page15 extends Module5 {
 }
 
 class Page16 extends Module5 {
+    constructor() {
+        super(
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708639374/audio-slices-less-pauses/slice96_less_pauses_revised_u8kay3.wav",
+        );
+    }
     text(): JSX.Element | Array<JSX.Element> {
         return [
+            <button key="playButton" onClick={this.playAudio}>
+                Play Audio
+            </button>,
+            <audio
+                key="audioElement"
+                ref={this.audioRef}
+                style={{ visibility: "hidden" }}
+                autoPlay={true}
+                src={this.audioUrl}
+            ></audio>,
             <p>
                 In Go, the placement of a single stone can make the difference between capturing a
                 large group or losing one of your own. That's part of the fun!

--- a/src/views/Matchmaking/ComputerOpponents.tsx
+++ b/src/views/Matchmaking/ComputerOpponents.tsx
@@ -64,7 +64,7 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
                             const [race, idx] = uiClassToRaceIdx(bot.ui_class);
                             const handicaps =
                                 bot.kidsgo_bot_name?.toLowerCase()?.indexOf("easy") >= 0
-                                    ? [4, 2, 0]
+                                    ? [6, 4, 2, 0]
                                     : [0];
 
                             return (

--- a/src/views/Matchmaking/ComputerOpponents.tsx
+++ b/src/views/Matchmaking/ComputerOpponents.tsx
@@ -75,6 +75,9 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
                                         if (
                                             bot.kidsgo_bot_name?.toLowerCase()?.indexOf("easy") >= 0
                                         ) {
+                                            if (handicap === 6) {
+                                                botDisplayName = "Beginner + 6";
+                                            }
                                             if (handicap === 4) {
                                                 botDisplayName = "Beginner";
                                             } else if (handicap === 2) {

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -371,7 +371,7 @@ export function Matchmaking(): JSX.Element {
                         <option value="3">3</option>
                         <option value="4">4</option>
                         <option value="5">5</option>
-                        {/* <option value="6">6</option> */}
+                        <option value="6">6</option>
                     </select>
                     {handicap === 1 ? " starting stone and no komi " : " extra stones. "}
                 </div>


### PR DESCRIPTION
- To get setup locally, follow the instructions in the readme of this repo (main branch)
- Added audio to match the text in modules 1-5 (Go to the learn to play page, then click the 1, 2, 3, 4, or 5 to access these 5 modules)  [learn-to-play page](http://localhost:18888/learn-to-play)
- Added a play audio button to each module, which plays the audio when clicked (if the audio is off)
- Adjusted the styling (positioning and wording) on the learn to play page
- Added "Beginner +6" bot again, as we removed it previously